### PR TITLE
Adding writers to filefolder

### DIFF
--- a/src/clojure/alfresco/filefolder.clj
+++ b/src/clojure/alfresco/filefolder.clj
@@ -46,8 +46,8 @@
   ([parent child-name child-type]
    (.getNodeRef (.create (file-folder-service) parent child-name child-type))))
 
-(defn get-file-folder-writer
-  "Returns the ContentWriter for the given node & property (default to cm:content).
+(defn get-writer
+  "Returns the ContentWriter for the given node. Not the same as content/get-writer.
    Should not normally be used directly - write! is preferable."
   ([node] (.getWriter (file-folder-service) node)))
 
@@ -59,10 +59,10 @@
   ([src node]          (write! (ByteArrayInputStream. (.getBytes src "UTF-8")) node)))
 
 (defmethod write! java.io.InputStream
-  ([src node]          (.putContent (get-file-folder-writer node) src)))
+  ([src node]          (.putContent (get-writer node) src)))
 
 (defmethod write! java.io.File
-  ([src node]          (.putContent (get-file-folder-writer node) src)))
+  ([src node]          (.putContent (get-writer node) src)))
 
 (defn delete!
   "Deletes the given node.  Note: duplicate of alfresco.nodes/delete!."

--- a/src/clojure/alfresco/filefolder.clj
+++ b/src/clojure/alfresco/filefolder.clj
@@ -19,6 +19,7 @@
             [alfresco.nodes :as n])
   (:import [org.alfresco.service.cmr.model FileFolderService
                                            FileInfo]
+           [java.io File ByteArrayInputStream]
            [org.alfresco.model ContentModel]))
 
 (defn ^FileFolderService file-folder-service
@@ -44,6 +45,24 @@
    (.getNodeRef (.create (file-folder-service) parent child-name ContentModel/TYPE_CONTENT)))
   ([parent child-name child-type]
    (.getNodeRef (.create (file-folder-service) parent child-name child-type))))
+
+(defn get-file-folder-writer
+  "Returns the ContentWriter for the given node & property (default to cm:content).
+   Should not normally be used directly - write! is preferable."
+  ([node] (.getWriter (file-folder-service) node)))
+
+(defmulti write!
+  "Writes content to the given file or folder"
+  #(type (first %&)))
+
+(defmethod write! java.lang.String
+  ([src node]          (write! (ByteArrayInputStream. (.getBytes src "UTF-8")) node)))
+
+(defmethod write! java.io.InputStream
+  ([src node]          (.putContent (get-file-folder-writer node) src)))
+
+(defmethod write! java.io.File
+  ([src node]          (.putContent (get-file-folder-writer node) src)))
 
 (defn delete!
   "Deletes the given node.  Note: duplicate of alfresco.nodes/delete!."


### PR DESCRIPTION
I used the following to verify. Only real difference in putting the content to file is the af/write! instead of ac/write! The content.clj can still be used for advanced use cases. But as we already know now it doesnt handle mime type. Maybe, we could make a contentless document content url when we are creating the document, e.g. using the string write! below when we create the document with empty string. For example contentWriter.guessMimetype(filename) and then write! "".

user=> (at/in-tx-as (aa/admin)
  #_=>   (let [test-folder-name "test"
  #_=>         test-folder      (af/find-by-path test-folder-name (an/company-home))
  #_=>         test-folder      (if test-folder
  #_=>                            test-folder
  #_=>                            (af/create! (an/company-home) test-folder-name org.alfresco.model.ContentModel/TYPE_FOLDER))
  #_=>         test-file        (af/create! test-folder (str "test-" (.getTime (java.util.Date.)) ".txt"))] 
  #_=>     (an/add-aspect! test-file "cm:versionable" nil)
  #_=>     (af/write! "The quick brown fox jumps over the lazy dog." test-file)
  #_=>     nil))
Custom behaviour called with 2 args:
 Type: class org.alfresco.service.cmr.repository.NodeRef, Value: workspace://SpacesStore/d28f6dbe-0822-4741-ace6-a62b6b0b0a73
Type: class org.alfresco.service.namespace.QName, Value: {http://www.alfresco.org/model/content/1.0}versionable
nil
user=> (require '[alfresco.nodes :as n])

user=> (clojure.pprint/pprint
  #_=>        (a/as-admin
  #_=>         (n/properties (NodeRef. "workspace://SpacesStore/d28f6dbe-0822-4741-ace6-a62b6b0b0a73"))))
{#<QName {http://www.alfresco.org/model/content/1.0}created>
 #inst "2014-12-16T20:07:16.449-00:00",
.....
....... contentUrl=store://2014/12/16/21/7/225020b8-351d-435e-9d17-91a98291b419.bin|mimetype=text/plain|size=44|encoding=UTF-8|locale=en_GB_|id=224....
....
nil
